### PR TITLE
JRL script rerun result

### DIFF
--- a/jrl/a/a-1010.json
+++ b/jrl/a/a-1010.json
@@ -354,43 +354,6 @@
               }
             }
           ]
-        },
-        {
-          "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~3397~108777/canvas/c1",
-          "@type": "sc:Canvas",
-          "label": "8+9 / 9 leaves (4 x 2 conjoined), recto",
-          "height": 4017,
-          "width": 5350,
-          "images": [
-            {
-              "@type": "oa:Annotation",
-              "motivation": "sc:painting",
-              "resource": {
-                "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/ManchesterDev~95~2~3397~108777/full/full/0/default.jpg",
-                "@type": "dctypes:Image",
-                "format": "image/jpeg",
-                "height": 4017,
-                "width": 5350,
-                "service": {
-                  "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/ManchesterDev~95~2~3397~108777",
-                  "profile": "http://iiif.io/api/image/2/level0.json"
-                }
-              },
-              "on": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~3397~108777/canvas/c1"
-            }
-          ],
-          "partOf": [
-            {
-              "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~3397~108777/manifest",
-              "@type": "sc:Manifest",
-              "label": {
-                "en": [
-                  "original source: A 1010 - 9"
-                ]
-              }
-            }
-          ]
         }
       ]
     }

--- a/jrl/a/a-1252.json
+++ b/jrl/a/a-1252.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~66132~112323/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 5350,
           "width": 4017,
           "images": [

--- a/jrl/a/a-1261.json
+++ b/jrl/a/a-1261.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~3530~112355/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1+2 / 2 leaves conjoined, recto",
+          "label": "1+2 / 2 leaves conjoined, verso",
           "height": 4017,
           "width": 5350,
           "images": [

--- a/jrl/a/a-1290.json
+++ b/jrl/a/a-1290.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~11276~107690/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 4017,
           "width": 5350,
           "images": [

--- a/jrl/a/a-1291.json
+++ b/jrl/a/a-1291.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~11284~107692/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 5350,
           "width": 4017,
           "images": [

--- a/jrl/a/a-131.json
+++ b/jrl/a/a-131.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~13916~113035/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 4017,
           "width": 5350,
           "images": [

--- a/jrl/a/a-1319.json
+++ b/jrl/a/a-1319.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~66735~107745/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 5350,
           "width": 4017,
           "images": [

--- a/jrl/a/a-1334.json
+++ b/jrl/a/a-1334.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~66775~112409/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 5350,
           "width": 4017,
           "images": [

--- a/jrl/a/a-1347.json
+++ b/jrl/a/a-1347.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~66955~112437/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 5350,
           "width": 4017,
           "images": [

--- a/jrl/a/a-1368.json
+++ b/jrl/a/a-1368.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~67326~112485/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 5350,
           "width": 4017,
           "images": [

--- a/jrl/a/a-1370.json
+++ b/jrl/a/a-1370.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~67334~112487/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 5350,
           "width": 4017,
           "images": [

--- a/jrl/a/a-1371.json
+++ b/jrl/a/a-1371.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~67342~112489/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 5350,
           "width": 4017,
           "images": [

--- a/jrl/a/a-1416.json
+++ b/jrl/a/a-1416.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~68953~112587/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 4017,
           "width": 5350,
           "images": [

--- a/jrl/a/a-1430.json
+++ b/jrl/a/a-1430.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~69932~112614/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 5350,
           "width": 4017,
           "images": [

--- a/jrl/a/a-1476.json
+++ b/jrl/a/a-1476.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~70158~112722/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 5350,
           "width": 4017,
           "images": [

--- a/jrl/a/a-1498.json
+++ b/jrl/a/a-1498.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~70716~112811/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 5350,
           "width": 4017,
           "images": [

--- a/jrl/a/a-1521.json
+++ b/jrl/a/a-1521.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~70816~112859/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 5350,
           "width": 4017,
           "images": [

--- a/jrl/a/a-1621.json
+++ b/jrl/a/a-1621.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~64992~106455/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 2 leaves, recto",
+          "label": "1 / 2 leaves, verso",
           "height": 5350,
           "width": 4017,
           "images": [

--- a/jrl/a/a-1631.json
+++ b/jrl/a/a-1631.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~72297~113198/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 2 leaves, recto",
+          "label": "1 / 2 leaves, verso",
           "height": 5350,
           "width": 4017,
           "images": [

--- a/jrl/a/a-174.json
+++ b/jrl/a/a-174.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~14758~109065/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 5350,
           "width": 4017,
           "images": [

--- a/jrl/a/a-400.json
+++ b/jrl/a/a-400.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~17596~109577/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 5350,
           "width": 4017,
           "images": [

--- a/jrl/a/a-42.json
+++ b/jrl/a/a-42.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~834~119476/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 5350,
           "width": 4017,
           "images": [

--- a/jrl/a/a-501.json
+++ b/jrl/a/a-501.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~18468~111252/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 5350,
           "width": 4017,
           "images": [

--- a/jrl/a/a-521.json
+++ b/jrl/a/a-521.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~18637~111294/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 6362,
           "width": 4777,
           "images": [

--- a/jrl/a/a-537.json
+++ b/jrl/a/a-537.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~65031~111334/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 6362,
           "width": 4777,
           "images": [

--- a/jrl/a/a-617.json
+++ b/jrl/a/a-617.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~19247~110238/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 5350,
           "width": 4017,
           "images": [

--- a/jrl/a/a-726.json
+++ b/jrl/a/a-726.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~65506~108056/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 4017,
           "width": 5350,
           "images": [

--- a/jrl/a/a-816.json
+++ b/jrl/a/a-816.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~65943~107330/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 5350,
           "width": 4017,
           "images": [

--- a/jrl/a/a-821.json
+++ b/jrl/a/a-821.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~20699~107340/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 5350,
           "width": 4017,
           "images": [

--- a/jrl/a/a-877.json
+++ b/jrl/a/a-877.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~20894~108471/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 5350,
           "width": 4017,
           "images": [

--- a/jrl/a/a-913.json
+++ b/jrl/a/a-913.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~67258~108543/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 4017,
           "width": 5350,
           "images": [

--- a/jrl/af/af-371.json
+++ b/jrl/af/af-371.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~164051~132867/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 4017,
           "width": 5350,
           "images": [

--- a/jrl/af/af-376.json
+++ b/jrl/af/af-376.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~164101~132877/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 4017,
           "width": 5350,
           "images": [

--- a/jrl/b/b-2295.json
+++ b/jrl/b/b-2295.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~137641~118580/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 5350,
           "width": 4017,
           "images": [

--- a/jrl/b/b-2326.json
+++ b/jrl/b/b-2326.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~77100~118623/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 5350,
           "width": 4017,
           "images": [

--- a/jrl/b/b-2992.json
+++ b/jrl/b/b-2992.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~85610~116851/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 5340,
           "width": 4005,
           "images": [

--- a/jrl/b/b-3487.json
+++ b/jrl/b/b-3487.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~24424~101825/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 4071,
           "width": 5422,
           "images": [

--- a/jrl/b/b-3525.json
+++ b/jrl/b/b-3525.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~26316~101904/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 5422,
           "width": 4071,
           "images": [

--- a/jrl/b/b-3605.json
+++ b/jrl/b/b-3605.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~27758~102083/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 4071,
           "width": 5422,
           "images": [

--- a/jrl/b/b-3700.json
+++ b/jrl/b/b-3700.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~30466~102283/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 5422,
           "width": 4071,
           "images": [

--- a/jrl/b/b-3776.json
+++ b/jrl/b/b-3776.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~31712~102454/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 5422,
           "width": 4071,
           "images": [

--- a/jrl/b/b-3885.json
+++ b/jrl/b/b-3885.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~28380~102672/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 5422,
           "width": 4071,
           "images": [

--- a/jrl/b/b-3958.json
+++ b/jrl/b/b-3958.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~33765~102848/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 4071,
           "width": 5422,
           "images": [

--- a/jrl/b/b-3960.json
+++ b/jrl/b/b-3960.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~33781~102852/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 5422,
           "width": 4071,
           "images": [

--- a/jrl/b/b-4102.json
+++ b/jrl/b/b-4102.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~40786~103307/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 5422,
           "width": 4071,
           "images": [

--- a/jrl/b/b-4128.json
+++ b/jrl/b/b-4128.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~40898~103220/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 5422,
           "width": 4071,
           "images": [

--- a/jrl/b/b-4254.json
+++ b/jrl/b/b-4254.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~42247~103612/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 5350,
           "width": 4017,
           "images": [

--- a/jrl/b/b-4275.json
+++ b/jrl/b/b-4275.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~42336~103654/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 4017,
           "width": 5350,
           "images": [

--- a/jrl/b/b-4787.json
+++ b/jrl/b/b-4787.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~49175~104910/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 5350,
           "width": 4017,
           "images": [

--- a/jrl/b/b-4946.json
+++ b/jrl/b/b-4946.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~22509~105248/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 4017,
           "width": 5350,
           "images": [

--- a/jrl/b/b-5229.json
+++ b/jrl/b/b-5229.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~52971~105700/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 4017,
           "width": 5350,
           "images": [

--- a/jrl/b/b-5735.json
+++ b/jrl/b/b-5735.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~58748~113503/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 5350,
           "width": 4017,
           "images": [

--- a/jrl/b/b-5799.json
+++ b/jrl/b/b-5799.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~59583~107482/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 5350,
           "width": 4017,
           "images": [

--- a/jrl/b/b-5890.json
+++ b/jrl/b/b-5890.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~60924~112960/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 4017,
           "width": 5350,
           "images": [

--- a/jrl/b/b-6098.json
+++ b/jrl/b/b-6098.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~65621~117087/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 4005,
           "width": 5340,
           "images": [

--- a/jrl/b/b-6247.json
+++ b/jrl/b/b-6247.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~87559~117441/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 4005,
           "width": 5340,
           "images": [

--- a/jrl/b/b-6260.json
+++ b/jrl/b/b-6260.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~87681~117467/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 5340,
           "width": 4005,
           "images": [

--- a/jrl/b/b-6310.json
+++ b/jrl/b/b-6310.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~88670~117573/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 5340,
           "width": 4005,
           "images": [

--- a/jrl/b/b-6612.json
+++ b/jrl/b/b-6612.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~92558~118521/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 5350,
           "width": 4017,
           "images": [

--- a/jrl/b/b-7930.json
+++ b/jrl/b/b-7930.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~110111~122424/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 3 leaves, recto",
+          "label": "1 / 3 leaves, verso",
           "height": 4017,
           "width": 5350,
           "images": [

--- a/jrl/gaster/gaster-printed-652.json
+++ b/jrl/gaster/gaster-printed-652.json
@@ -62,7 +62,7 @@
         {
           "@id": "https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~154161~131012/canvas/c1",
           "@type": "sc:Canvas",
-          "label": "1 / 1 leaf, recto",
+          "label": "1 / 1 leaf, verso",
           "height": 5350,
           "width": 4017,
           "images": [


### PR DESCRIPTION
Here's the result of running the new version of the iiif script, seems to be working!

Note that there is one canvas that seems to have gone missing from the source, JRL SERIES A 1010 sequence number 9:
- Missing manifest: https://luna.manchester.ac.uk/luna/servlet/iiif/m/ManchesterDev~95~2~3397~108777/manifest
- Search: https://luna.manchester.ac.uk/luna/servlet/view/search?q=reference_number%3D%22A+1010%22+LIMIT%3AManchesterDev~95~&sort=reference_number%2Cdate_created,JRL