### PR TITLE
Manifest dimensions updates for updated Bodleian images

### DIFF
--- a/bodleian/c/ms-heb-c-13-10.json
+++ b/bodleian/c/ms-heb-c-13-10.json
@@ -53,8 +53,8 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/c/canvas/ms-heb-c-13-10/2.json",
           "@type": "sc:Canvas",
           "label": "10 verso",
-          "height": 3583,
-          "width": 4290,
+          "height": 4219,
+          "width": 3497,
           "images": [
             {
               "@id": "https://princetongenizalab.github.io/iiif/bodleian/c/canvas/ms-heb-c-13-10/2.json/anno1",
@@ -64,8 +64,8 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_c_13_10b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 3583,
-                "width": 4290,
+                "height": 4219,
+                "width": 3497,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
                   "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_c_13_10b",

--- a/bodleian/c/ms-heb-c-13-11.json
+++ b/bodleian/c/ms-heb-c-13-11.json
@@ -53,8 +53,8 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/c/canvas/ms-heb-c-13-11/2.json",
           "@type": "sc:Canvas",
           "label": "11 verso",
-          "height": 4361,
-          "width": 5249,
+          "height": 3583,
+          "width": 4290,
           "images": [
             {
               "@id": "https://princetongenizalab.github.io/iiif/bodleian/c/canvas/ms-heb-c-13-11/2.json/anno1",
@@ -64,8 +64,8 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_c_13_11b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 4361,
-                "width": 5249,
+                "height": 3583,
+                "width": 4290,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
                   "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_c_13_11b",

--- a/bodleian/c/ms-heb-c-13-12.json
+++ b/bodleian/c/ms-heb-c-13-12.json
@@ -53,8 +53,8 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/c/canvas/ms-heb-c-13-12/2.json",
           "@type": "sc:Canvas",
           "label": "12 verso",
-          "height": 3592,
-          "width": 4524,
+          "height": 4361,
+          "width": 5249,
           "images": [
             {
               "@id": "https://princetongenizalab.github.io/iiif/bodleian/c/canvas/ms-heb-c-13-12/2.json/anno1",
@@ -64,8 +64,8 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_c_13_12b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 3592,
-                "width": 4524,
+                "height": 4361,
+                "width": 5249,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
                   "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_c_13_12b",

--- a/bodleian/c/ms-heb-c-13-13.json
+++ b/bodleian/c/ms-heb-c-13-13.json
@@ -53,8 +53,8 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/c/canvas/ms-heb-c-13-13/2.json",
           "@type": "sc:Canvas",
           "label": "13 verso",
-          "height": 4222,
-          "width": 5197,
+          "height": 3592,
+          "width": 4524,
           "images": [
             {
               "@id": "https://princetongenizalab.github.io/iiif/bodleian/c/canvas/ms-heb-c-13-13/2.json/anno1",
@@ -64,8 +64,8 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_c_13_13b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 4222,
-                "width": 5197,
+                "height": 3592,
+                "width": 4524,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
                   "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_c_13_13b",

--- a/bodleian/c/ms-heb-c-13-14.json
+++ b/bodleian/c/ms-heb-c-13-14.json
@@ -53,8 +53,8 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/c/canvas/ms-heb-c-13-14/2.json",
           "@type": "sc:Canvas",
           "label": "14 verso",
-          "height": 4714,
-          "width": 4161,
+          "height": 4222,
+          "width": 5197,
           "images": [
             {
               "@id": "https://princetongenizalab.github.io/iiif/bodleian/c/canvas/ms-heb-c-13-14/2.json/anno1",
@@ -64,8 +64,8 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_c_13_14b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 4714,
-                "width": 4161,
+                "height": 4222,
+                "width": 5197,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
                   "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_c_13_14b",

--- a/bodleian/c/ms-heb-c-13-15.json
+++ b/bodleian/c/ms-heb-c-13-15.json
@@ -53,8 +53,8 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/c/canvas/ms-heb-c-13-15/2.json",
           "@type": "sc:Canvas",
           "label": "15 verso",
-          "height": 5017,
-          "width": 6000,
+          "height": 4714,
+          "width": 4161,
           "images": [
             {
               "@id": "https://princetongenizalab.github.io/iiif/bodleian/c/canvas/ms-heb-c-13-15/2.json/anno1",
@@ -64,8 +64,8 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_c_13_15b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 5017,
-                "width": 6000,
+                "height": 4714,
+                "width": 4161,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
                   "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_c_13_15b",

--- a/bodleian/c/ms-heb-c-13-16.json
+++ b/bodleian/c/ms-heb-c-13-16.json
@@ -53,8 +53,8 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/c/canvas/ms-heb-c-13-16/2.json",
           "@type": "sc:Canvas",
           "label": "16 verso",
-          "height": 5759,
-          "width": 4558,
+          "height": 5017,
+          "width": 6000,
           "images": [
             {
               "@id": "https://princetongenizalab.github.io/iiif/bodleian/c/canvas/ms-heb-c-13-16/2.json/anno1",
@@ -64,8 +64,8 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_c_13_16b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 5759,
-                "width": 4558,
+                "height": 5017,
+                "width": 6000,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
                   "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_c_13_16b",

--- a/bodleian/c/ms-heb-c-13-17.json
+++ b/bodleian/c/ms-heb-c-13-17.json
@@ -53,8 +53,8 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/c/canvas/ms-heb-c-13-17/2.json",
           "@type": "sc:Canvas",
           "label": "17 verso",
-          "height": 5223,
-          "width": 4472,
+          "height": 5759,
+          "width": 4558,
           "images": [
             {
               "@id": "https://princetongenizalab.github.io/iiif/bodleian/c/canvas/ms-heb-c-13-17/2.json/anno1",
@@ -64,8 +64,8 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_c_13_17b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 5223,
-                "width": 4472,
+                "height": 5759,
+                "width": 4558,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
                   "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_c_13_17b",

--- a/bodleian/c/ms-heb-c-13-27.json
+++ b/bodleian/c/ms-heb-c-13-27.json
@@ -26,8 +26,8 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/c/canvas/ms-heb-c-13-27/1.json",
           "@type": "sc:Canvas",
           "label": "27 recto",
-          "height": 8730,
-          "width": 3445,
+          "height": 7993,
+          "width": 6000,
           "images": [
             {
               "@id": "https://princetongenizalab.github.io/iiif/bodleian/c/canvas/ms-heb-c-13-27/1.json/anno1",
@@ -37,8 +37,8 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_c_13_27a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 8730,
-                "width": 3445,
+                "height": 7993,
+                "width": 6000,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
                   "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_c_13_27a",
@@ -53,8 +53,8 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/c/canvas/ms-heb-c-13-27/2.json",
           "@type": "sc:Canvas",
           "label": "27 verso",
-          "height": 8721,
-          "width": 3548,
+          "height": 8045,
+          "width": 6000,
           "images": [
             {
               "@id": "https://princetongenizalab.github.io/iiif/bodleian/c/canvas/ms-heb-c-13-27/2.json/anno1",
@@ -64,8 +64,8 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_c_13_27b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 8721,
-                "width": 3548,
+                "height": 8045,
+                "width": 6000,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
                   "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_c_13_27b",

--- a/bodleian/d/ms-heb-d-74-1.json
+++ b/bodleian/d/ms-heb-d-74-1.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-1/1.json",
           "@type": "sc:Canvas",
           "label": "1 recto",
-          "height": 5294,
+          "height": 4598,
           "width": 4992,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_1a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 5294,
+                "height": 4598,
                 "width": 4992,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-1/2.json",
           "@type": "sc:Canvas",
           "label": "1 verso",
-          "height": 5273,
+          "height": 4577,
           "width": 4734,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_1b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 5273,
+                "height": 4577,
                 "width": 4734,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",

--- a/bodleian/d/ms-heb-d-74-10.json
+++ b/bodleian/d/ms-heb-d-74-10.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-10/1.json",
           "@type": "sc:Canvas",
           "label": "10 recto",
-          "height": 6059,
+          "height": 5363,
           "width": 3916,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_10a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6059,
+                "height": 5363,
                 "width": 3916,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-10/2.json",
           "@type": "sc:Canvas",
           "label": "10 verso",
-          "height": 6156,
+          "height": 5460,
           "width": 4056,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_10b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6156,
+                "height": 5460,
                 "width": 4056,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",

--- a/bodleian/d/ms-heb-d-74-11.json
+++ b/bodleian/d/ms-heb-d-74-11.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-11/1.json",
           "@type": "sc:Canvas",
           "label": "11 recto",
-          "height": 6059,
+          "height": 5363,
           "width": 3916,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_11a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6059,
+                "height": 5363,
                 "width": 3916,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-11/2.json",
           "@type": "sc:Canvas",
           "label": "11 verso",
-          "height": 6156,
+          "height": 5460,
           "width": 3991,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_11b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6156,
+                "height": 5460,
                 "width": 3991,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",

--- a/bodleian/d/ms-heb-d-74-12.json
+++ b/bodleian/d/ms-heb-d-74-12.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-12/1.json",
           "@type": "sc:Canvas",
           "label": "12 recto",
-          "height": 6059,
+          "height": 5363,
           "width": 3916,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_12a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6059,
+                "height": 5363,
                 "width": 3916,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-12/2.json",
           "@type": "sc:Canvas",
           "label": "12 verso",
-          "height": 6199,
+          "height": 5503,
           "width": 4013,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_12b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6199,
+                "height": 5503,
                 "width": 4013,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",

--- a/bodleian/d/ms-heb-d-74-13.json
+++ b/bodleian/d/ms-heb-d-74-13.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-13/1.json",
           "@type": "sc:Canvas",
           "label": "13 recto",
-          "height": 6059,
+          "height": 5363,
           "width": 3722,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_13a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6059,
+                "height": 5363,
                 "width": 3722,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-13/2.json",
           "@type": "sc:Canvas",
           "label": "13 verso",
-          "height": 6080,
+          "height": 5384,
           "width": 3852,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_13b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6080,
+                "height": 5384,
                 "width": 3852,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",

--- a/bodleian/d/ms-heb-d-74-14.json
+++ b/bodleian/d/ms-heb-d-74-14.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-14/1.json",
           "@type": "sc:Canvas",
           "label": "14 recto",
-          "height": 6199,
+          "height": 5503,
           "width": 4562,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_14a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6199,
+                "height": 5503,
                 "width": 4562,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-14/2.json",
           "@type": "sc:Canvas",
           "label": "14 verso",
-          "height": 6242,
+          "height": 5546,
           "width": 4680,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_14b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6242,
+                "height": 5546,
                 "width": 4680,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",

--- a/bodleian/d/ms-heb-d-74-15.json
+++ b/bodleian/d/ms-heb-d-74-15.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-15/1.json",
           "@type": "sc:Canvas",
           "label": "15 recto",
-          "height": 6199,
+          "height": 5503,
           "width": 4927,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_15a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6199,
+                "height": 5503,
                 "width": 4927,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-15/2.json",
           "@type": "sc:Canvas",
           "label": "15 verso",
-          "height": 6295,
+          "height": 5599,
           "width": 4736,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_15b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6295,
+                "height": 5599,
                 "width": 4736,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",

--- a/bodleian/d/ms-heb-d-74-16.json
+++ b/bodleian/d/ms-heb-d-74-16.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-16/1.json",
           "@type": "sc:Canvas",
           "label": "16 recto",
-          "height": 6199,
+          "height": 5503,
           "width": 4562,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_16a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6199,
+                "height": 5503,
                 "width": 4562,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-16/2.json",
           "@type": "sc:Canvas",
           "label": "16 verso",
-          "height": 6156,
+          "height": 5460,
           "width": 4540,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_16b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6156,
+                "height": 5460,
                 "width": 4540,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",

--- a/bodleian/d/ms-heb-d-74-17.json
+++ b/bodleian/d/ms-heb-d-74-17.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-17/1.json",
           "@type": "sc:Canvas",
           "label": "17 recto",
-          "height": 6435,
+          "height": 5739,
           "width": 4561,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_17a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6435,
+                "height": 5739,
                 "width": 4561,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-17/2.json",
           "@type": "sc:Canvas",
           "label": "17 verso",
-          "height": 6436,
+          "height": 5740,
           "width": 4303,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_17b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6436,
+                "height": 5740,
                 "width": 4303,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",

--- a/bodleian/d/ms-heb-d-74-18.json
+++ b/bodleian/d/ms-heb-d-74-18.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-18/1.json",
           "@type": "sc:Canvas",
           "label": "18 recto",
-          "height": 5704,
+          "height": 5008,
           "width": 4561,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_18a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 5704,
+                "height": 5008,
                 "width": 4561,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-18/2.json",
           "@type": "sc:Canvas",
           "label": "18 verso",
-          "height": 5714,
+          "height": 5018,
           "width": 4562,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_18b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 5714,
+                "height": 5018,
                 "width": 4562,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",

--- a/bodleian/d/ms-heb-d-74-19.json
+++ b/bodleian/d/ms-heb-d-74-19.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-19/1.json",
           "@type": "sc:Canvas",
           "label": "19 recto",
-          "height": 5048,
+          "height": 4352,
           "width": 5309,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_19a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 5048,
+                "height": 4352,
                 "width": 5309,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-19/2.json",
           "@type": "sc:Canvas",
           "label": "19 verso",
-          "height": 4892,
+          "height": 4196,
           "width": 5309,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_19b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 4892,
+                "height": 4196,
                 "width": 5309,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",

--- a/bodleian/d/ms-heb-d-74-2.json
+++ b/bodleian/d/ms-heb-d-74-2.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-2/1.json",
           "@type": "sc:Canvas",
           "label": "2 recto",
-          "height": 6457,
+          "height": 5761,
           "width": 4712,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_2a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6457,
+                "height": 5761,
                 "width": 4712,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-2/2.json",
           "@type": "sc:Canvas",
           "label": "2 verso",
-          "height": 6285,
+          "height": 5589,
           "width": 4841,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_2b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6285,
+                "height": 5589,
                 "width": 4841,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",

--- a/bodleian/d/ms-heb-d-74-20.json
+++ b/bodleian/d/ms-heb-d-74-20.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-20/1.json",
           "@type": "sc:Canvas",
           "label": "20 recto",
-          "height": 4854,
+          "height": 4158,
           "width": 5067,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_20a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 4854,
+                "height": 4158,
                 "width": 5067,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-20/2.json",
           "@type": "sc:Canvas",
           "label": "20 verso",
-          "height": 5139,
+          "height": 4443,
           "width": 5169,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_20b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 5139,
+                "height": 4443,
                 "width": 5169,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",

--- a/bodleian/d/ms-heb-d-74-21.json
+++ b/bodleian/d/ms-heb-d-74-21.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-21/1.json",
           "@type": "sc:Canvas",
           "label": "21 recto",
-          "height": 6005,
+          "height": 5309,
           "width": 4260,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_21a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6005,
+                "height": 5309,
                 "width": 4260,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-21/2.json",
           "@type": "sc:Canvas",
           "label": "21 verso",
-          "height": 6037,
+          "height": 5341,
           "width": 4572,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_21b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6037,
+                "height": 5341,
                 "width": 4572,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",

--- a/bodleian/d/ms-heb-d-74-22.json
+++ b/bodleian/d/ms-heb-d-74-22.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-22/1.json",
           "@type": "sc:Canvas",
           "label": "22 recto",
-          "height": 5251,
+          "height": 4555,
           "width": 4497,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_22a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 5251,
+                "height": 4555,
                 "width": 4497,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-22/2.json",
           "@type": "sc:Canvas",
           "label": "22 verso",
-          "height": 5424,
+          "height": 4728,
           "width": 4454,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_22b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 5424,
+                "height": 4728,
                 "width": 4454,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",

--- a/bodleian/d/ms-heb-d-74-23.json
+++ b/bodleian/d/ms-heb-d-74-23.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-23/1.json",
           "@type": "sc:Canvas",
           "label": "23 recto",
-          "height": 5714,
+          "height": 5018,
           "width": 4551,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_23a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 5714,
+                "height": 5018,
                 "width": 4551,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-23/2.json",
           "@type": "sc:Canvas",
           "label": "23 verso",
-          "height": 5650,
+          "height": 4954,
           "width": 4680,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_23b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 5650,
+                "height": 4954,
                 "width": 4680,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",

--- a/bodleian/d/ms-heb-d-74-24.json
+++ b/bodleian/d/ms-heb-d-74-24.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-24/1.json",
           "@type": "sc:Canvas",
           "label": "24 recto",
-          "height": 6088,
+          "height": 5392,
           "width": 4468,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_24a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6088,
+                "height": 5392,
                 "width": 4468,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-24/2.json",
           "@type": "sc:Canvas",
           "label": "24 verso",
-          "height": 6156,
+          "height": 5460,
           "width": 4551,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_24b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6156,
+                "height": 5460,
                 "width": 4551,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",

--- a/bodleian/d/ms-heb-d-74-25.json
+++ b/bodleian/d/ms-heb-d-74-25.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-25/1.json",
           "@type": "sc:Canvas",
           "label": "25 recto",
-          "height": 6348,
+          "height": 5652,
           "width": 4512,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_25a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6348,
+                "height": 5652,
                 "width": 4512,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-25/2.json",
           "@type": "sc:Canvas",
           "label": "25 verso",
-          "height": 6371,
+          "height": 5675,
           "width": 4691,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_25b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6371,
+                "height": 5675,
                 "width": 4691,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",

--- a/bodleian/d/ms-heb-d-74-26.json
+++ b/bodleian/d/ms-heb-d-74-26.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-26/1.json",
           "@type": "sc:Canvas",
           "label": "26 recto",
-          "height": 5919,
+          "height": 5223,
           "width": 4465,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_26a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 5919,
+                "height": 5223,
                 "width": 4465,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-26/2.json",
           "@type": "sc:Canvas",
           "label": "26 verso",
-          "height": 5887,
+          "height": 5191,
           "width": 4508,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_26b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 5887,
+                "height": 5191,
                 "width": 4508,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",

--- a/bodleian/d/ms-heb-d-74-27.json
+++ b/bodleian/d/ms-heb-d-74-27.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-27/1.json",
           "@type": "sc:Canvas",
           "label": "27 recto",
-          "height": 6339,
+          "height": 5643,
           "width": 4680,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_27a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6339,
+                "height": 5643,
                 "width": 4680,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-27/2.json",
           "@type": "sc:Canvas",
           "label": "27 verso",
-          "height": 6220,
+          "height": 5524,
           "width": 4702,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_27b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6220,
+                "height": 5524,
                 "width": 4702,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",

--- a/bodleian/d/ms-heb-d-74-28.json
+++ b/bodleian/d/ms-heb-d-74-28.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-28/1.json",
           "@type": "sc:Canvas",
           "label": "28 recto",
-          "height": 6244,
+          "height": 5548,
           "width": 4515,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_28a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6244,
+                "height": 5548,
                 "width": 4515,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-28/2.json",
           "@type": "sc:Canvas",
           "label": "28 verso",
-          "height": 6231,
+          "height": 5535,
           "width": 4755,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_28b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6231,
+                "height": 5535,
                 "width": 4755,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",

--- a/bodleian/d/ms-heb-d-74-29.json
+++ b/bodleian/d/ms-heb-d-74-29.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-29/1.json",
           "@type": "sc:Canvas",
           "label": "29 recto",
-          "height": 6307,
+          "height": 5611,
           "width": 4519,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_29a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6307,
+                "height": 5611,
                 "width": 4519,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-29/2.json",
           "@type": "sc:Canvas",
           "label": "29 verso",
-          "height": 6307,
+          "height": 5611,
           "width": 4712,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_29b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6307,
+                "height": 5611,
                 "width": 4712,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",

--- a/bodleian/d/ms-heb-d-74-3.json
+++ b/bodleian/d/ms-heb-d-74-3.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-3/1.json",
           "@type": "sc:Canvas",
           "label": "3 recto",
-          "height": 6457,
+          "height": 5761,
           "width": 4712,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_3a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6457,
+                "height": 5761,
                 "width": 4712,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-3/2.json",
           "@type": "sc:Canvas",
           "label": "3 verso",
-          "height": 6285,
+          "height": 5589,
           "width": 4841,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_3b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6285,
+                "height": 5589,
                 "width": 4841,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",

--- a/bodleian/d/ms-heb-d-74-30.json
+++ b/bodleian/d/ms-heb-d-74-30.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-30/1.json",
           "@type": "sc:Canvas",
           "label": "30 recto",
-          "height": 5876,
+          "height": 5180,
           "width": 4454,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_30a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 5876,
+                "height": 5180,
                 "width": 4454,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-30/2.json",
           "@type": "sc:Canvas",
           "label": "30 verso",
-          "height": 5779,
+          "height": 5083,
           "width": 4755,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_30b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 5779,
+                "height": 5083,
                 "width": 4755,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",

--- a/bodleian/d/ms-heb-d-74-31.json
+++ b/bodleian/d/ms-heb-d-74-31.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-31/1.json",
           "@type": "sc:Canvas",
           "label": "31 recto",
-          "height": 5768,
+          "height": 5072,
           "width": 4604,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_31a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 5768,
+                "height": 5072,
                 "width": 4604,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-31/2.json",
           "@type": "sc:Canvas",
           "label": "31 verso",
-          "height": 5747,
+          "height": 5051,
           "width": 4723,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_31b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 5747,
+                "height": 5051,
                 "width": 4723,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",

--- a/bodleian/d/ms-heb-d-74-32.json
+++ b/bodleian/d/ms-heb-d-74-32.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-32/1.json",
           "@type": "sc:Canvas",
           "label": "32 recto",
-          "height": 6070,
+          "height": 5374,
           "width": 4325,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_32a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6070,
+                "height": 5374,
                 "width": 4325,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-32/2.json",
           "@type": "sc:Canvas",
           "label": "32 verso",
-          "height": 6102,
+          "height": 5406,
           "width": 4508,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_32b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6102,
+                "height": 5406,
                 "width": 4508,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",

--- a/bodleian/d/ms-heb-d-74-33.json
+++ b/bodleian/d/ms-heb-d-74-33.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-33/1.json",
           "@type": "sc:Canvas",
           "label": "33 recto",
-          "height": 5553,
+          "height": 4857,
           "width": 4669,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_33a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 5553,
+                "height": 4857,
                 "width": 4669,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-33/2.json",
           "@type": "sc:Canvas",
           "label": "33 verso",
-          "height": 5488,
+          "height": 4792,
           "width": 4561,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_33b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 5488,
+                "height": 4792,
                 "width": 4561,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",

--- a/bodleian/d/ms-heb-d-74-34.json
+++ b/bodleian/d/ms-heb-d-74-34.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-34/1.json",
           "@type": "sc:Canvas",
           "label": "34 recto",
-          "height": 5144,
+          "height": 4448,
           "width": 4626,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_34a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 5144,
+                "height": 4448,
                 "width": 4626,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-34/2.json",
           "@type": "sc:Canvas",
           "label": "34 verso",
-          "height": 5154,
+          "height": 4458,
           "width": 4831,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_34b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 5154,
+                "height": 4458,
                 "width": 4831,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",

--- a/bodleian/d/ms-heb-d-74-35.json
+++ b/bodleian/d/ms-heb-d-74-35.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-35/1.json",
           "@type": "sc:Canvas",
           "label": "35 recto",
-          "height": 5919,
+          "height": 5223,
           "width": 4519,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_35a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 5919,
+                "height": 5223,
                 "width": 4519,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-35/2.json",
           "@type": "sc:Canvas",
           "label": "35 verso",
-          "height": 5940,
+          "height": 5244,
           "width": 4723,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_35b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 5940,
+                "height": 5244,
                 "width": 4723,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",

--- a/bodleian/d/ms-heb-d-74-36.json
+++ b/bodleian/d/ms-heb-d-74-36.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-36/1.json",
           "@type": "sc:Canvas",
           "label": "36 recto",
-          "height": 5488,
+          "height": 4792,
           "width": 4648,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_36a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 5488,
+                "height": 4792,
                 "width": 4648,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-36/2.json",
           "@type": "sc:Canvas",
           "label": "36 verso",
-          "height": 5596,
+          "height": 4900,
           "width": 4755,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_36b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 5596,
+                "height": 4900,
                 "width": 4755,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",

--- a/bodleian/d/ms-heb-d-74-37.json
+++ b/bodleian/d/ms-heb-d-74-37.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-37/1.json",
           "@type": "sc:Canvas",
           "label": "37 recto",
-          "height": 5855,
+          "height": 5159,
           "width": 4541,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_37a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 5855,
+                "height": 5159,
                 "width": 4541,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-37/2.json",
           "@type": "sc:Canvas",
           "label": "37 verso",
-          "height": 5940,
+          "height": 5244,
           "width": 4443,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_37b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 5940,
+                "height": 5244,
                 "width": 4443,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",

--- a/bodleian/d/ms-heb-d-74-38.json
+++ b/bodleian/d/ms-heb-d-74-38.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-38/1.json",
           "@type": "sc:Canvas",
           "label": "38 recto",
-          "height": 6350,
+          "height": 5654,
           "width": 4712,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_38a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6350,
+                "height": 5654,
                 "width": 4712,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-38/2.json",
           "@type": "sc:Canvas",
           "label": "38 verso",
-          "height": 6296,
+          "height": 5600,
           "width": 4852,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_38b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6296,
+                "height": 5600,
                 "width": 4852,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",

--- a/bodleian/d/ms-heb-d-74-39.json
+++ b/bodleian/d/ms-heb-d-74-39.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-39/1.json",
           "@type": "sc:Canvas",
           "label": "39 recto",
-          "height": 5854,
+          "height": 5158,
           "width": 4368,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_39a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 5854,
+                "height": 5158,
                 "width": 4368,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-39/2.json",
           "@type": "sc:Canvas",
           "label": "39 verso",
-          "height": 5876,
+          "height": 5180,
           "width": 4551,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_39b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 5876,
+                "height": 5180,
                 "width": 4551,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",

--- a/bodleian/d/ms-heb-d-74-4.json
+++ b/bodleian/d/ms-heb-d-74-4.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-4/1.json",
           "@type": "sc:Canvas",
           "label": "4 recto",
-          "height": 6457,
+          "height": 5761,
           "width": 4712,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_4a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6457,
+                "height": 5761,
                 "width": 4712,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-4/2.json",
           "@type": "sc:Canvas",
           "label": "4 verso",
-          "height": 6285,
+          "height": 5589,
           "width": 4433,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_4b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6285,
+                "height": 5589,
                 "width": 4433,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",

--- a/bodleian/d/ms-heb-d-74-40.json
+++ b/bodleian/d/ms-heb-d-74-40.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-40/1.json",
           "@type": "sc:Canvas",
           "label": "40 recto",
-          "height": 5230,
+          "height": 4534,
           "width": 4691,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_40a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 5230,
+                "height": 4534,
                 "width": 4691,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-40/2.json",
           "@type": "sc:Canvas",
           "label": "40 verso",
-          "height": 5359,
+          "height": 4663,
           "width": 4852,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_40b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 5359,
+                "height": 4663,
                 "width": 4852,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",

--- a/bodleian/d/ms-heb-d-74-41.json
+++ b/bodleian/d/ms-heb-d-74-41.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-41/1.json",
           "@type": "sc:Canvas",
           "label": "41 recto",
-          "height": 5129,
+          "height": 4433,
           "width": 5137,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_41a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 5129,
+                "height": 4433,
                 "width": 5137,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-41/2.json",
           "@type": "sc:Canvas",
           "label": "41 verso",
-          "height": 5042,
+          "height": 4346,
           "width": 5244,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_41b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 5042,
+                "height": 4346,
                 "width": 5244,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",

--- a/bodleian/d/ms-heb-d-74-42.json
+++ b/bodleian/d/ms-heb-d-74-42.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-42/1.json",
           "@type": "sc:Canvas",
           "label": "42 recto",
-          "height": 5876,
+          "height": 5180,
           "width": 4691,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_42a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 5876,
+                "height": 5180,
                 "width": 4691,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-42/2.json",
           "@type": "sc:Canvas",
           "label": "42 verso",
-          "height": 5897,
+          "height": 5201,
           "width": 4992,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_42b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 5897,
+                "height": 5201,
                 "width": 4992,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",

--- a/bodleian/d/ms-heb-d-74-43.json
+++ b/bodleian/d/ms-heb-d-74-43.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-43/1.json",
           "@type": "sc:Canvas",
           "label": "43 recto",
-          "height": 6048,
+          "height": 5352,
           "width": 4669,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_43a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6048,
+                "height": 5352,
                 "width": 4669,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-43/2.json",
           "@type": "sc:Canvas",
           "label": "43 verso",
-          "height": 6199,
+          "height": 5503,
           "width": 4637,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_43b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6199,
+                "height": 5503,
                 "width": 4637,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",

--- a/bodleian/d/ms-heb-d-74-44.json
+++ b/bodleian/d/ms-heb-d-74-44.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-44/1.json",
           "@type": "sc:Canvas",
           "label": "44 recto",
-          "height": 5381,
+          "height": 4685,
           "width": 4540,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_44a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 5381,
+                "height": 4685,
                 "width": 4540,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-44/2.json",
           "@type": "sc:Canvas",
           "label": "44 verso",
-          "height": 5520,
+          "height": 4824,
           "width": 4335,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_44b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 5520,
+                "height": 4824,
                 "width": 4335,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",

--- a/bodleian/d/ms-heb-d-74-45.json
+++ b/bodleian/d/ms-heb-d-74-45.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-45/1.json",
           "@type": "sc:Canvas",
           "label": "45 recto",
-          "height": 5079,
+          "height": 4383,
           "width": 4820,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_45a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 5079,
+                "height": 4383,
                 "width": 4820,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-45/2.json",
           "@type": "sc:Canvas",
           "label": "45 verso",
-          "height": 5111,
+          "height": 4415,
           "width": 4955,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_45b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 5111,
+                "height": 4415,
                 "width": 4955,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",

--- a/bodleian/d/ms-heb-d-74-46.json
+++ b/bodleian/d/ms-heb-d-74-46.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-46/1.json",
           "@type": "sc:Canvas",
           "label": "46 recto",
-          "height": 6414,
+          "height": 5718,
           "width": 4691,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_46a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6414,
+                "height": 5718,
                 "width": 4691,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,8 +53,8 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-46/2.json",
           "@type": "sc:Canvas",
           "label": "46 verso",
-          "height": 4992,
-          "width": 6328,
+          "height": 5632,
+          "width": 4992,
           "images": [
             {
               "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-46/2.json/anno1",
@@ -64,8 +64,8 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_46b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 4992,
-                "width": 6328,
+                "height": 5632,
+                "width": 4992,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
                   "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_46b",

--- a/bodleian/d/ms-heb-d-74-47.json
+++ b/bodleian/d/ms-heb-d-74-47.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-47/1.json",
           "@type": "sc:Canvas",
           "label": "47 recto",
-          "height": 6651,
+          "height": 5955,
           "width": 4755,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_47a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6651,
+                "height": 5955,
                 "width": 4755,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-47/2.json",
           "@type": "sc:Canvas",
           "label": "47 verso",
-          "height": 6530,
+          "height": 5834,
           "width": 4885,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_47b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6530,
+                "height": 5834,
                 "width": 4885,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",

--- a/bodleian/d/ms-heb-d-74-5.json
+++ b/bodleian/d/ms-heb-d-74-5.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-5/1.json",
           "@type": "sc:Canvas",
           "label": "5 recto",
-          "height": 6242,
+          "height": 5546,
           "width": 4454,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_5a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6242,
+                "height": 5546,
                 "width": 4454,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-5/2.json",
           "@type": "sc:Canvas",
           "label": "5 verso",
-          "height": 6048,
+          "height": 5352,
           "width": 4411,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_5b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6048,
+                "height": 5352,
                 "width": 4411,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",

--- a/bodleian/d/ms-heb-d-74-6.json
+++ b/bodleian/d/ms-heb-d-74-6.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-6/1.json",
           "@type": "sc:Canvas",
           "label": "6 recto",
-          "height": 5768,
+          "height": 5072,
           "width": 4390,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_6a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 5768,
+                "height": 5072,
                 "width": 4390,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-6/2.json",
           "@type": "sc:Canvas",
           "label": "6 verso",
-          "height": 5789,
+          "height": 5093,
           "width": 4454,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_6b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 5789,
+                "height": 5093,
                 "width": 4454,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",

--- a/bodleian/d/ms-heb-d-74-7.json
+++ b/bodleian/d/ms-heb-d-74-7.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-7/1.json",
           "@type": "sc:Canvas",
           "label": "7 recto",
-          "height": 5585,
+          "height": 4889,
           "width": 3798,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_7a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 5585,
+                "height": 4889,
                 "width": 3798,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-7/2.json",
           "@type": "sc:Canvas",
           "label": "7 verso",
-          "height": 5574,
+          "height": 4878,
           "width": 4196,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_7b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 5574,
+                "height": 4878,
                 "width": 4196,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",

--- a/bodleian/d/ms-heb-d-74-8.json
+++ b/bodleian/d/ms-heb-d-74-8.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-8/1.json",
           "@type": "sc:Canvas",
           "label": "8 recto",
-          "height": 6059,
+          "height": 5363,
           "width": 3916,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_8a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6059,
+                "height": 5363,
                 "width": 3916,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-8/2.json",
           "@type": "sc:Canvas",
           "label": "8 verso",
-          "height": 6048,
+          "height": 5352,
           "width": 4067,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_8b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6048,
+                "height": 5352,
                 "width": 4067,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",

--- a/bodleian/d/ms-heb-d-74-9.json
+++ b/bodleian/d/ms-heb-d-74-9.json
@@ -26,7 +26,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-9/1.json",
           "@type": "sc:Canvas",
           "label": "9 recto",
-          "height": 6059,
+          "height": 5363,
           "width": 3916,
           "images": [
             {
@@ -37,7 +37,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_9a/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6059,
+                "height": 5363,
                 "width": 3916,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
@@ -53,7 +53,7 @@
           "@id": "https://princetongenizalab.github.io/iiif/bodleian/d/canvas/ms-heb-d-74-9/2.json",
           "@type": "sc:Canvas",
           "label": "9 verso",
-          "height": 6134,
+          "height": 5438,
           "width": 4217,
           "images": [
             {
@@ -64,7 +64,7 @@
                 "@id": "https://puliiif.princeton.edu/iiif/2/MS_HEB_d_74_9b/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
-                "height": 6134,
+                "height": 5438,
                 "width": 4217,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",


### PR DESCRIPTION
Updated images discovered as part of work in https://github.com/Princeton-CDH/geniza/issues/1198, this PR just updates the dimensions in the manifests for the appropriate images.

Per https://github.com/Princeton-CDH/geniza/issues/1198#issuecomment-1437760334, it seems like wrong images are going to be a small number of cases and are a result of issues on the Bodleian end. So we don't need to reupload all PTIFFs and can just handle them as they come.